### PR TITLE
Replace app-experiment-info with a local component for full text control

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTabsModule } from '@angular/material/tabs';
@@ -9,12 +10,14 @@ import { PhoenixUIModule } from 'phoenix-ui-components';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { ATLASComponent } from './pages/atlas/atlas.component';
+import { ExperimentInfoComponent } from './components/experiment-info/experiment-info.component';
 
 @NgModule({
-  declarations: [AppComponent, ATLASComponent],
+  declarations: [AppComponent, ATLASComponent, ExperimentInfoComponent],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
+    DragDropModule,
     PhoenixUIModule,
     AppRoutingModule,
     MatDialogModule,

--- a/src/app/components/experiment-info/experiment-info.component.html
+++ b/src/app/components/experiment-info/experiment-info.component.html
@@ -1,0 +1,17 @@
+<div id="experimentInfo" class="experimentInfo" cdkDrag cdkDragBoundary="body">
+  <a
+    class="experimentLogoWrapper"
+    target="_blank"
+    rel="noopener noreferrer"
+    *ngIf="url"
+    [href]="url"
+  >
+    <img class="experimentLogo" [src]="logo" alt="" />
+  </a>
+  <div class="textInfo">
+    <p *ngFor="let field of runEventFields">
+      <b>{{ field.label }}: </b>{{ field.value }}
+    </p>
+    <p *ngIf="dateTime">{{ dateTime }}</p>
+  </div>
+</div>

--- a/src/app/components/experiment-info/experiment-info.component.scss
+++ b/src/app/components/experiment-info/experiment-info.component.scss
@@ -1,0 +1,49 @@
+.experimentInfo {
+  position: absolute;
+  top: 5rem;
+  left: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-family: 'Courier New', 'Lucida Console', monospace;
+  cursor: move;
+}
+
+.experimentLogoWrapper {
+  width: 9rem;
+  margin-bottom: 0.5rem;
+
+  .experimentLogo {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.textInfo {
+  text-align: center;
+
+  p {
+    color: white;
+    font-size: 0.8rem;
+    margin-bottom: 0.5rem;
+    user-select: none;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .experimentInfo {
+    top: 4rem;
+    max-width: 40%;
+  }
+
+  .experimentLogoWrapper {
+    height: 4rem;
+  }
+
+  .textInfo {
+    display: none;
+  }
+}

--- a/src/app/components/experiment-info/experiment-info.component.ts
+++ b/src/app/components/experiment-info/experiment-info.component.ts
@@ -1,0 +1,66 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { EventDisplayService } from 'phoenix-ui-components';
+
+interface InfoField {
+  label: string;
+  value: string;
+}
+
+// Custom replacement for phoenix-ui-components' <app-experiment-info>.
+// That component combines Run/Event/LumiBlock into a single pre-joined
+// string (e.g. "Run / Event / LumiBlock: 336567 / 2327102923 / 794") and
+// exposes no input to reformat it, so per the phoenix maintainers'
+// guidance (github.com/ATLAS-experiment/PhoenixATLAS/issues/27) this is
+// copied and adapted locally to show Run and Event on their own lines,
+// drop LumiBlock, and show the recorded date/time without a label.
+@Component({
+  selector: 'atlas-experiment-info',
+  standalone: false,
+  templateUrl: './experiment-info.component.html',
+  styleUrls: ['./experiment-info.component.scss'],
+})
+export class ExperimentInfoComponent implements OnInit, OnDestroy {
+  @Input() url?: string;
+  @Input() logo?: string;
+
+  runEventFields: InfoField[] = [];
+  dateTime = '';
+
+  private unsubscribe?: () => void;
+
+  constructor(private eventDisplay: EventDisplayService) {}
+
+  ngOnInit() {
+    this.unsubscribe = this.eventDisplay.listenToDisplayedEventChange(() => {
+      this.updateInfo();
+    });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe?.();
+  }
+
+  private updateInfo() {
+    const metadata: InfoField[] = this.eventDisplay.getEventMetadata();
+    const runEventFields: InfoField[] = [];
+    let dateTime = '';
+
+    for (const field of metadata) {
+      if (field.label === 'Data recorded') {
+        dateTime = field.value;
+        continue;
+      }
+
+      const labels = field.label.split(' / ');
+      const values = field.value.split(' / ');
+      labels.forEach((label, i) => {
+        if (label !== 'LumiBlock' && label !== 'LS') {
+          runEventFields.push({ label, value: values[i] });
+        }
+      });
+    }
+
+    this.runEventFields = runEventFields;
+    this.dateTime = dateTime;
+  }
+}

--- a/src/app/pages/atlas/atlas.component.html
+++ b/src/app/pages/atlas/atlas.component.html
@@ -5,10 +5,9 @@
   <app-event-data-explorer [apiURL]="apiURL"></app-event-data-explorer>
 </app-ui-menu>
 <app-embed-menu></app-embed-menu>
-<app-experiment-info
+<atlas-experiment-info
   logo="assets/images/ATLAS_logo_white_on_transparent.png"
   url="https://home.cern/science/experiments/atlas"
-  tagline=""
-></app-experiment-info>
+></atlas-experiment-info>
 <app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
 <div id="eventDisplay"></div>


### PR DESCRIPTION
Added a local ExperimentInfoComponent (atlas-experiment-info) that reads the same getEventMetadata()/listenToDisplayedEventChange() API but splits the combined Run/Event/LumiBlock string back into individual fields, dropping LumiBlock and rendering Run/Event on their own lines, then the recorded date/time on its own line.